### PR TITLE
Fix errors during robot initialization when robot is unreachable

### DIFF
--- a/src/robomaster/client.py
+++ b/src/robomaster/client.py
@@ -65,7 +65,7 @@ class Client(object):
             try:
                 self._conn = conn.Connection(config.ROBOT_DEFAULT_LOCAL_WIFI_ADDR,
                                              config.ROBOT_DEFAULT_WIFI_ADDR,
-                                             protocol=config.DEFAULT_CONN_PROTO)
+                                             protocol=config.DEFAULT_PROTO_TYPE)
             except Exception as e:
                 logger.error('Client: __init__, create Connection, exception: {0}'.format(e))
                 self._conn = None
@@ -89,10 +89,7 @@ class Client(object):
 
     @property
     def remote_addr(self):
-        try:
-            return self._conn.target_addr
-        except Exception:
-            raise print('Robot: Can not connect to robot, check connection please.')
+        return self._conn.target_addr if self._conn else None
 
     def add_handler(self, obj, name, f):
         self._dispatcher.add_handler(obj, name, f)
@@ -129,7 +126,7 @@ class Client(object):
             raise e
 
     def stop(self):
-        if self._thread.is_alive():
+        if self._thread and self._thread.is_alive():
             self._running = False
             proto = protocol.ProtoGetVersion()
             msg = protocol.Msg(self.hostbyte, self.hostbyte, proto)

--- a/src/robomaster/robot.py
+++ b/src/robomaster/robot.py
@@ -1145,7 +1145,7 @@ class Robot(RobotBase):
 
     @property
     def ip(self):
-        return self.client.remote_addr[0]
+        return self.client.remote_addr[0] if self.client.remote_addr else None
 
     @property
     def conn_type(self):
@@ -1298,7 +1298,7 @@ class Robot(RobotBase):
             self._client.start()
         except Exception as e:
             logger.error("Robot: Connection Create Failed.")
-            raise e
+            return False
 
         self._action_dispatcher = action.ActionDispatcher(self.client)
         self._action_dispatcher.initialize()


### PR DESCRIPTION
Hi,

when initializing a Robomaster EP robot, which is actually unreachable, the current SDK crashes with various errors, which have been fixed by this pull request. 

One error was due to an incorrectly written constant, another one due to wrong python exception raising syntax. 

The remaining error were caused by only partially initialized member variables when the code could not establish a connection to the robot.

Please consider these fixes for an update for a better user experience when using the SDK.

Regards,
Sascha