### PR TITLE
Catch EADDRINUSE in scan_robot_ip on bind

### DIFF
--- a/src/robomaster/conn.py
+++ b/src/robomaster/conn.py
@@ -22,6 +22,7 @@ import queue
 import random
 import time
 import base64
+import errno
 from ftplib import FTP
 from . import algo
 from . import protocol
@@ -77,15 +78,24 @@ def scan_robot_ip(user_sn=None, timeout=3.0):
                 end = time.time()
                 if end - start > timeout:
                     break
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                s.bind(("0.0.0.0", config.ROBOT_BROADCAST_PORT))
-                s.settimeout(1)
-                data, ip = s.recvfrom(1024)
-                recv_sn = get_sn_form_data(data)
-                logger.info("conn: scan_robot_ip, data:{0}, ip:{1}".format(recv_sn, ip))
-                if recv_sn == user_sn:
-                    robot_ip = ip[0]
-                    find_robot = True
+
+                try:
+                    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    s.bind(("0.0.0.0", config.ROBOT_BROADCAST_PORT))
+                    s.settimeout(1)
+                    data, ip = s.recvfrom(1024)
+                    recv_sn = get_sn_form_data(data)
+                    logger.info("conn: scan_robot_ip, data:{0}, ip:{1}".format(recv_sn, ip))
+                    if recv_sn == user_sn:
+                        robot_ip = ip[0]
+                        find_robot = True
+                except socket.error as error:
+                    # If multiple processes trying to connected to different
+                    # RoboMasters are started at the same time, the socket will
+                    # not be able to bind. In that case, try again until timeout.
+                    if not error.errno == errno.EADDRINUSE:
+                        raise
+
             if robot_ip:
                 return robot_ip
             else:


### PR DESCRIPTION
I am currently working on a very simple ROS2 driver for the RoboMaster. I don't want to use the MultiRobot API, instead, I want to start multiple processes that connect to each robot with the single robot API (it makes more sense to have an independent ROS node for each robot).
This works if I start the nodes independently, but if they are launched at the same time in a launch file, only one of the processes will be able to send the UDP broadcast and the other ones will throw the EADDRINUSE exception. In this PR, I catch this specific error code (raise all other ones), therefore if multiple processes attempt an IP scan at the same time, it will just wait for the timeout instead of failing immediately.