### PR TITLE
Fix: Action Object Couldn't  Get Currect Error Message From Robot

### DIFF
--- a/src/robomaster/action.py
+++ b/src/robomaster/action.py
@@ -241,8 +241,11 @@ class TextAction(Action):
             self._changeto_state(ACTION_SUCCEEDED)
         elif proto_state == 'error':
             self._changeto_state(ACTION_FAILED)
+            self._failure_reason = proto_state
             logger.error("TextAction: action failed ! resp: {0}".format(proto_state))
         else:
+            self._changeto_state(ACTION_FAILED)
+            self._failure_reason = proto_state
             logger.error("TextAction: action failed ! resp: {0}".format(proto_state))
 
     def make_action_key(self):


### PR DESCRIPTION
无人机返回的错误值，无法在Action对象中通过failure_reason方法获取，而且无论无人机是否正确执行动作，has_faild始终为True